### PR TITLE
Add connection credential feature to the cloud config client

### DIFF
--- a/cloud-config-client/src/main/java/org/squirrelframework/cloud/conf/ZkClientFactoryBean.java
+++ b/cloud-config-client/src/main/java/org/squirrelframework/cloud/conf/ZkClientFactoryBean.java
@@ -4,11 +4,13 @@ import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.framework.CuratorFrameworkFactory.Builder;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 
 import static org.squirrelframework.cloud.utils.CloudConfigCommon.ZK_CONNECT_STRING_KEY;
+import static org.squirrelframework.cloud.utils.CloudConfigCommon.ZK_CREDENTIAL_STRING_KEY;
 
 /**
  * Created by kailianghe on 8/29/15.
@@ -19,7 +21,11 @@ public class ZkClientFactoryBean extends AbstractFactoryBean<CuratorFramework> i
 
     public static final int BASE_SLEEP_TIME = 3000;
 
+    public static final String SCHEME_DIGEST = "digest";
+
     private String connectionString;
+
+    private String credentialString;
 
     private int maxRetries = MAX_RETRIES;
 
@@ -42,12 +48,19 @@ public class ZkClientFactoryBean extends AbstractFactoryBean<CuratorFramework> i
         }
 
         RetryPolicy retryPolicy = new ExponentialBackoffRetry(baseSleepTime, maxRetries);
-        CuratorFramework client = CuratorFrameworkFactory.builder()
-                .connectString(connectionString)
-                .retryPolicy(retryPolicy)
-                .canBeReadOnly(canReadOnly)
-                .build();
+        Builder curatorFrameworkBuilder = CuratorFrameworkFactory.builder()
+            .connectString(connectionString)
+            .retryPolicy(retryPolicy)
+            .canBeReadOnly(canReadOnly);        
+        
+        String credentialString = resolveCredentialString();
+        if(credentialString!=null) {
+            curatorFrameworkBuilder.authorization(SCHEME_DIGEST, credentialString.getBytes());
+        }
+        
+        CuratorFramework client = curatorFrameworkBuilder.build();
         client.start();
+        
         return client;
     }
 
@@ -59,6 +72,10 @@ public class ZkClientFactoryBean extends AbstractFactoryBean<CuratorFramework> i
 
     public void setConnectionString(String connectionString) {
         this.connectionString = connectionString;
+    }
+
+    public void setCredentialString(String credentialString) {
+        this.credentialString = credentialString;
     }
 
     public void setMaxRetries(int maxRetries) {
@@ -83,5 +100,12 @@ public class ZkClientFactoryBean extends AbstractFactoryBean<CuratorFramework> i
             return environment.getProperty(ZK_CONNECT_STRING_KEY);
         }
         return connectionString;
+    }
+
+    private String resolveCredentialString() {
+        if(environment.containsProperty(ZK_CREDENTIAL_STRING_KEY)) {
+            return environment.getProperty(ZK_CREDENTIAL_STRING_KEY);
+        }
+        return credentialString;
     }
 }

--- a/cloud-config-client/src/main/java/org/squirrelframework/cloud/spring/ZkClientBeanDefinitionParser.java
+++ b/cloud-config-client/src/main/java/org/squirrelframework/cloud/spring/ZkClientBeanDefinitionParser.java
@@ -28,6 +28,11 @@ public class ZkClientBeanDefinitionParser extends AbstractSingleBeanDefinitionPa
         if(StringUtils.hasLength(connectionString)) {
             builder.addPropertyValue("connectionString", connectionString);
         }
+        
+        String credentialString = element.getAttribute("credential-string");
+        if(StringUtils.hasLength(credentialString)) {
+            builder.addPropertyValue("credentialString", credentialString);
+        }
 
         Integer maxRetries = getSafeInteger(element.getAttribute("max-retries"));
         if(maxRetries!=null) {

--- a/cloud-config-client/src/main/java/org/squirrelframework/cloud/utils/CloudConfigCommon.java
+++ b/cloud-config-client/src/main/java/org/squirrelframework/cloud/utils/CloudConfigCommon.java
@@ -18,6 +18,8 @@ public abstract class CloudConfigCommon {
 
     public static final String ZK_CONNECT_STRING_KEY = "config.center.url";
 
+    public static final String ZK_CREDENTIAL_STRING_KEY = "config.center.acl";
+
     public static final String NAMESPACE = getConfProperty("namespace", "root");
 
     public static final String PROPERTY_ROOT = NAMESPACE + "/properties";

--- a/cloud-config-client/src/main/resources/org/squirrelframework/cloud/spring/cloud-config-1.0.xsd
+++ b/cloud-config-client/src/main/resources/org/squirrelframework/cloud/spring/cloud-config-1.0.xsd
@@ -19,6 +19,7 @@
             <xsd:attribute type="xsd:integer" name="base-sleep-time"/>
             <xsd:attribute type="xsd:boolean" name="read-only" default="true"/>
             <xsd:attribute type="xsd:string" name="connection-string"/>
+            <xsd:attribute type="xsd:string" name="credential-string"/>
         </xsd:complexType>
     </xsd:element>
 


### PR DESCRIPTION
This change enables cloud config client use a credential string to specify a digest ACL while connecting the ZooKeeper server.

The connection credential string could be specified as
1. JVM launch argument: `-Dconfig.center.acl=user:password`
2. spring configuration: `<cc:zk-client connection-string="127.0.0.1:1234" credential-string="user:password"/>`

The ACL specified in the first approach will override the second if they have been both provided.
