### PR TITLE
Allow specifying multiple “user:passwd” entries in credential string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cloud-config is a multi-tenant-aware configuaration center based on Zookeeper an
         http://www.squirrelframework.org/schema/config
         http://www.squirrelframework.org/schema/config/cloud-config.xsd">
     	<!-- config zookeeper client -->
-    	<cc:zk-client connection-string="127.0.0.1:2181"/>
+    	<cc:zk-client connection-string="127.0.0.1:2181" credential-string="user:passwd"/>
 		<!-- config as property place holder -->
 		<cc:zk-property-placeholder path="/mail, /query" location="classpath:query-server.properties"/>
     	<!-- config as jdbc dataSource -->

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,8 +68,8 @@ mail.password=dev1234
             http://www.squirrelframework.org/schema/config
             http://www.squirrelframework.org/schema/config/cloud-config.xsd">
 
-    <!--配置用于读取配置信息的zookeeper client，connection string在系统启动时，可通过指定-Dconfig.center.url覆盖-->    
-    <cc:zk-client connection-string="127.0.0.1:1234"/>
+    <!--配置用于读取配置信息的zookeeper client，connection string在系统启动时，可通过指定-Dconfig.center.url覆盖; credential string用于指定读取zookeeper node所需的认证信息(可指定多个用户名密码对)，可通过指定-Dconfig.center.acl覆盖-->    
+    <cc:zk-client connection-string="127.0.0.1:1234" credential-string="user:passwd"/>
 
     <!--zk-property-placeholder中可以在path属性上同时指定多个配置路径（相对于{namesapce}/properties)，路径在前者优先-->
     <!--zk-property-placeholder中可以在location中引入本地配置文件，local-override为true时本地配置将覆盖zk中的配置-->    

--- a/cloud-config-client/pom.xml
+++ b/cloud-config-client/pom.xml
@@ -45,21 +45,25 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
+            <version>[2.10.0,)</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
+            <version>[2.10.0,)</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
+            <version>[2.10.0,)</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
+            <version>[2.10.0,)</version>
         </dependency>
 
         <dependency>

--- a/cloud-config-client/src/main/java/org/squirrelframework/cloud/conf/ZkClientFactoryBean.java
+++ b/cloud-config-client/src/main/java/org/squirrelframework/cloud/conf/ZkClientFactoryBean.java
@@ -5,12 +5,20 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.framework.CuratorFrameworkFactory.Builder;
+import org.apache.curator.framework.AuthInfo;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 import static org.squirrelframework.cloud.utils.CloudConfigCommon.ZK_CONNECT_STRING_KEY;
 import static org.squirrelframework.cloud.utils.CloudConfigCommon.ZK_CREDENTIAL_STRING_KEY;
+import static org.squirrelframework.cloud.utils.CloudConfigCommon.STRING_ARRAY_SEPARATOR;
+
+import org.apache.commons.codec.binary.Base64;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by kailianghe on 8/29/15.
@@ -55,7 +63,20 @@ public class ZkClientFactoryBean extends AbstractFactoryBean<CuratorFramework> i
         
         String credentialString = resolveCredentialString();
         if(credentialString!=null) {
-            curatorFrameworkBuilder.authorization(SCHEME_DIGEST, credentialString.getBytes());
+              String[] credentials = StringUtils.tokenizeToStringArray(credentialString, STRING_ARRAY_SEPARATOR);
+              
+              List<AuthInfo> authList = new ArrayList<AuthInfo>();
+              for(String cred : credentials){
+                  String[] aclId = cred.split(":");
+                  String passwd = new String(Base64.decodeBase64(aclId[1].trim()),"UTF-8");
+                  authList.add(new AuthInfo(
+                      SCHEME_DIGEST, 
+                      String.format("%s:%s", aclId[0].trim(), passwd).getBytes()));    
+              }
+              
+              if(!authList.isEmpty()) {
+                  curatorFrameworkBuilder.authorization(authList);
+              }
         }
         
         CuratorFramework client = curatorFrameworkBuilder.build();


### PR DESCRIPTION
Allow specifying multiple “user:passwd” entries in credential string, require Apache Curator's version above 2.9.0
