### PR TITLE
tomcat不能正常关闭

### DIFF
--- a/cloud-config-client/src/main/java/org/squirrelframework/cloud/utils/CloudConfigCommon.java
+++ b/cloud-config-client/src/main/java/org/squirrelframework/cloud/utils/CloudConfigCommon.java
@@ -2,6 +2,7 @@ package org.squirrelframework.cloud.utils;
 
 import com.google.common.cache.CacheLoader;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;

--- a/cloud-config-client/src/main/java/org/squirrelframework/cloud/utils/CloudConfigCommon.java
+++ b/cloud-config-client/src/main/java/org/squirrelframework/cloud/utils/CloudConfigCommon.java
@@ -48,7 +48,7 @@ public abstract class CloudConfigCommon {
 
     public static final String SEQUENCE_VALUE_KEY = "sequenceValue";
 
-    public static final ExecutorService EVENT_EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
+    public static final ExecutorService EVENT_EXECUTOR_SERVICE = Executors.newSingleThreadExecutor(ThreadUtils.newThreadFactory("zk-event"));
 
     public static final String STRING_ARRAY_SEPARATOR = " ,;|";
 


### PR DESCRIPTION
引入cloud-config-client后，发现tomcat不能正常shutdown。hack代码后，发现是EVENT_EXECUTOR_SERVICE初始化时，走的是默认的DefaultThreadFactory。
